### PR TITLE
Handle errors with Promises

### DIFF
--- a/android/src/main/java/com/xebia/activityrecognition/ActivityRecognizer.java
+++ b/android/src/main/java/com/xebia/activityrecognition/ActivityRecognizer.java
@@ -61,6 +61,10 @@ public class ActivityRecognizer implements ConnectionCallbacks, OnConnectionFail
 
     // Subscribe to activity updates. If not connected to Google Play Services, connect first and try again from the onConnected callback.
     public void start(long detectionIntervalMillis) {
+        if (mGoogleApiClient == null) {
+            throw new Error("No Google API client. Your device likely doesn't have Google Play Services.");
+        }
+
         interval = detectionIntervalMillis;
         if (!connected) {
             mGoogleApiClient.connect();
@@ -77,6 +81,10 @@ public class ActivityRecognizer implements ConnectionCallbacks, OnConnectionFail
 
     // Unsubscribe from activity updates and disconnect from Google Play Services. Also called when connection failed.
     public void stop() {
+        if (mGoogleApiClient == null) {
+            throw new Error("No Google API client. Your device likely doesn't have Google Play Services.");
+        }
+
         if (started) {
             ActivityRecognition.ActivityRecognitionApi.removeActivityUpdates(
                 mGoogleApiClient,

--- a/android/src/main/java/com/xebia/activityrecognition/RNActivityRecognitionNativeModule.java
+++ b/android/src/main/java/com/xebia/activityrecognition/RNActivityRecognitionNativeModule.java
@@ -23,17 +23,32 @@ public class RNActivityRecognitionNativeModule extends ReactContextBaseJavaModul
     }
 
     @ReactMethod
-    public void start(int detectionIntervalMillis) {
-        if (mActivityRecognizer == null) {
-            mActivityRecognizer = new ActivityRecognizer(mReactContext);
+    public void startWithCallback(int detectionIntervalMillis, final Callback onSuccess, final Callback onError) {
+        try {
+            if (mActivityRecognizer == null) {
+                mActivityRecognizer = new ActivityRecognizer(mReactContext);
+            }
+
+            mActivityRecognizer.start((long) detectionIntervalMillis);
+        } catch (Error e) {
+            onError.invoke(e.getMessage());
+            return;
         }
-        mActivityRecognizer.start(new Long(detectionIntervalMillis));
+
+        onSuccess.invoke();
     }
 
     @ReactMethod
-    public void stop() {
-        if (mActivityRecognizer != null) {
-            mActivityRecognizer.stop();
+    public void stopWithCallback(final Callback onSuccess, final Callback onError) {
+        try {
+            if (mActivityRecognizer != null) {
+                mActivityRecognizer.stop();
+            }
+        } catch (Error e) {
+            onError.invoke(e.getMessage());
+            return;
         }
+
+        onSuccess.invoke();
     }
 }

--- a/ios/RNActivityRecognition.m
+++ b/ios/RNActivityRecognition.m
@@ -69,31 +69,41 @@ float _timeout = 1.0;
     }
 }
 
-RCT_EXPORT_METHOD(startActivity:(float) time)
+RCT_EXPORT_METHOD(startActivity:(float)time callback:(RCTResponseSenderBlock)callback)
 {
-    checkActivityConfig();
+    NSString* errorMsg = checkActivityConfig(callback);
+    
+    if (errorMsg != nil) {
+        RCTLogError(@"%@", errorMsg);
+        callback(@[errorMsg]);
+        return;
+    }
+    
     _timeout = time/1000;
     RCTLogInfo(@"Starting Activity Detection");
     _timer = [NSTimer scheduledTimerWithTimeInterval: _timeout
                                               target:self selector:@selector(activityManager) userInfo:nil repeats:YES];
+    
+    callback(@[[NSNull null]]);
 }
 
-RCT_EXPORT_METHOD(stopActivity)
+RCT_EXPORT_METHOD(stopActivity:(RCTResponseSenderBlock)callback)
 {
     RCTLogInfo(@"Stopping Activity Detection");
     [self.motionActivityManager stopActivityUpdates];
     [_timer invalidate];
+    
+    callback(@[[NSNull null]]);
 }
 
-static void checkActivityConfig()
+static NSString* checkActivityConfig()
 {
 #if RCT_DEV
     if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMotionUsageDescription"]) {
-        RCTLogError(@"NSMotionUsageDescription key must be present in Info.plist to use Activity Manager.");
+        return @"NSMotionUsageDescription key must be present in Info.plist to use Activity Manager.";
     }
 #endif
+    return nil;
 }
 
-
 @end
-  

--- a/ios/RNActivityRecognition.m
+++ b/ios/RNActivityRecognition.m
@@ -65,7 +65,7 @@ float _timeout = 1.0;
                                                     }
          ];
     } else {
-        RCTLogInfo(@"Activity is Not Available on this device.");
+        RCTLogInfo(@"Motion data is not available on this device.");
     }
 }
 
@@ -101,6 +101,9 @@ static NSString* checkActivityConfig()
 #if RCT_DEV
     if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMotionUsageDescription"]) {
         return @"NSMotionUsageDescription key must be present in Info.plist to use Activity Manager.";
+    }
+    if (![CMMotionActivityManager isActivityAvailable]) {
+        return @"Motion data is not available on this device.";
     }
 #endif
     return nil;

--- a/ios/RNActivityRecognition.m
+++ b/ios/RNActivityRecognition.m
@@ -74,7 +74,7 @@ RCT_EXPORT_METHOD(startActivity:(float)time callback:(RCTResponseSenderBlock)cal
     NSString* errorMsg = checkActivityConfig(callback);
     
     if (errorMsg != nil) {
-        RCTLogError(@"%@", errorMsg);
+        NSLog(@"Error: %@", errorMsg);
         callback(@[errorMsg]);
         return;
     }

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -2,6 +2,8 @@ const { DeviceEventEmitter, NativeModules } = require('react-native')
 const { ActivityRecognition } = NativeModules
 
 ActivityRecognition.subscribe = subscribe
+ActivityRecognition.start = start
+ActivityRecognition.stop = stop
 
 function subscribe(callback) {
   const subscription = DeviceEventEmitter.addListener('DetectedActivity', detectedActivities => {
@@ -15,6 +17,23 @@ function subscribe(callback) {
     })
   })
   return () => DeviceEventEmitter.removeSubscription(subscription)
+}
+
+function start(detectionIntervalMs) {
+  return new Promise((resolve, reject) => {
+    ActivityRecognition.startWithCallback(detectionIntervalMs, resolve, logAndReject.bind(null, reject))
+  });
+}
+
+function stop() {
+  return new Promise((resolve, reject) => {
+    ActivityRecognition.stopWithCallback(resolve, logAndReject.bind(null, reject))
+  });
+}
+
+function logAndReject(reject, e) {
+  console.error(`[ActivityRecognition] Error: ${e}`)
+  reject(e)
 }
 
 module.exports = ActivityRecognition

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -31,9 +31,9 @@ function stop() {
   });
 }
 
-function logAndReject(reject, e) {
-  console.error(`[ActivityRecognition] Error: ${e}`)
-  reject(e)
+function logAndReject(reject, errorMsg) {
+  console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+  reject(errorMsg)
 }
 
 module.exports = ActivityRecognition

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -32,7 +32,8 @@ function stop() {
 }
 
 function logAndReject(reject, errorMsg) {
-  console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+  // Don't log this as an error, because the client should handle it using `catch`.
+  console.log(`[ActivityRecognition] Error: ${errorMsg}`)
   reject(errorMsg)
 }
 

--- a/src/ActivityRecognition.ios.js
+++ b/src/ActivityRecognition.ios.js
@@ -35,7 +35,8 @@ var ActivityRecognition = {
 
 function logAndReject(resolve, reject, errorMsg) {
   if (errorMsg) {
-    console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+    // Don't log this as an error, because the client should handle it using `catch`.
+    console.log(`[ActivityRecognition] Error: ${errorMsg}`)
     reject(errorMsg)
     return
   }

--- a/src/ActivityRecognition.ios.js
+++ b/src/ActivityRecognition.ios.js
@@ -6,27 +6,40 @@ const emitter = new NativeEventEmitter(RNActivityRecognition);
 var subscription = null;
 
 var ActivityRecognition = {
-    start: function(time: number) {
-        RNActivityRecognition.startActivity(time);
-    },
-    subscribe: function(success: Function) {
-        subscription = emitter.addListener(
-            "ActivityDetection",
-            activity => {
-                success({
-                    ...activity,
-                    get sorted() {
-                        return Object.keys(activity)
-                            .map(type => ({ type: type, confidence: activity[type] }))
-                    }
-                })
-            }
-        );
-        return () => subscription.remove();
-    },
-    stop: function() {
-        RNActivityRecognition.stopActivity();
-    }
+  start: function(time: number) {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.startActivity(time, logAndReject.bind(null, resolve, reject))
+    })
+  },
+  subscribe: function(success: Function) {
+    subscription = emitter.addListener(
+      "ActivityDetection",
+      activity => {
+        success({
+          ...activity,
+          get sorted() {
+            return Object.keys(activity)
+              .map(type => ({ type: type, confidence: activity[type] }))
+          }
+        })
+      }
+    );
+    return () => subscription.remove();
+  },
+  stop: function() {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.stopActivity(logAndReject.bind(null, resolve, reject))
+    })
+  }
+}
+
+function logAndReject(resolve, reject, errorMsg) {
+  if (errorMsg) {
+    console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+    reject(errorMsg)
+    return
+  }
+  resolve()
 }
 
 module.exports = ActivityRecognition;


### PR DESCRIPTION
### Motivation

Some simulators (for both iOS and Android) don't support activity recognition, and even some real Android devices don't have Google Play Services installed. For these devices, the app may crash with native error logs that never get sent to JS and thus are impossible to handle elegantly.

### Changes

- Return Promises for `start` and `stop` on both Android and iOS
- Fail to `start` on Android if Google Play Services doesn't exist, or on iOS if motion data isn't available (in `DEV`)
- Log issues to the JS console automatically, but allow them to be handled by the client
- Use consistent indentation in `ActivityRecognition.ios.js`
    - View the diff with whitespace ignored: https://github.com/Aminoid/react-native-activity-recognition/commit/219f2a37f6e4dc4025d9a5492c8e4c37773f06b8?w=1

### Example

```js
ActivityRecognition.start(1000)
  .then(() => console.log('Success'))
  .catch((errorMsg) => console.log(errorMsg));
```

### Notes

- Documentation on iOS callbacks: https://facebook.github.io/react-native/docs/native-modules-ios.html#callbacks