### PR TITLE
Add methods for using mock data

### DIFF
--- a/android/src/main/java/com/xebia/activityrecognition/ActivityRecognizer.java
+++ b/android/src/main/java/com/xebia/activityrecognition/ActivityRecognizer.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.Timer;
+import java.util.TimerTask;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
@@ -41,6 +42,7 @@ public class ActivityRecognizer implements ConnectionCallbacks, OnConnectionFail
     private boolean connected;
     private boolean started;
     private long interval;
+    private Timer mockTimer;
 
     public ActivityRecognizer(ReactApplicationContext reactContext) {
         mGoogleApiAvailability = GoogleApiAvailability.getInstance();
@@ -76,6 +78,30 @@ public class ActivityRecognizer implements ConnectionCallbacks, OnConnectionFail
                 getActivityDetectionPendingIntent()
             ).setResultCallback(this);
             started = true;
+        }
+    }
+
+    // Subscribe to mock activity updates.
+    public void startMocked(long detectionIntervalMillis, final int mockActivityType) {
+        mockTimer = new Timer();
+        mockTimer.scheduleAtFixedRate(new TimerTask() {
+            @Override
+            public void run() {
+                final ArrayList<DetectedActivity> detectedActivities = new ArrayList<>();
+                DetectedActivity detectedActivity = new DetectedActivity(mockActivityType, 100);
+                detectedActivities.add(detectedActivity);
+                onUpdate(detectedActivities);
+            }
+        }, 0, detectionIntervalMillis);
+
+        started = true;
+    }
+
+    // Unsubscribe from mock activity updates.
+    public void stopMocked() {
+        if (started) {
+            mockTimer.cancel();
+            started = false;
         }
     }
 

--- a/android/src/main/java/com/xebia/activityrecognition/ActivityRecognizer.java
+++ b/android/src/main/java/com/xebia/activityrecognition/ActivityRecognizer.java
@@ -61,6 +61,10 @@ public class ActivityRecognizer implements ConnectionCallbacks, OnConnectionFail
 
     // Subscribe to activity updates. If not connected to Google Play Services, connect first and try again from the onConnected callback.
     public void start(long detectionIntervalMillis) {
+        if (mGoogleApiClient == null) {
+            throw new Error("No Google API client. Your device likely doesn't have Google Play Services.");
+        }
+
         interval = detectionIntervalMillis;
         if (!connected) {
             mGoogleApiClient.connect();
@@ -77,6 +81,10 @@ public class ActivityRecognizer implements ConnectionCallbacks, OnConnectionFail
 
     // Unsubscribe from activity updates and disconnect from Google Play Services. Also called when connection failed.
     public void stop() {
+        if (mGoogleApiClient == null) {
+            throw new Error("No Google API client. Your device likely doesn't have Google Play Services.");
+        }
+
         if (started) {
             ActivityRecognition.ActivityRecognitionApi.removeActivityUpdates(
                 mGoogleApiClient,

--- a/android/src/main/java/com/xebia/activityrecognition/RNActivityRecognitionNativeModule.java
+++ b/android/src/main/java/com/xebia/activityrecognition/RNActivityRecognitionNativeModule.java
@@ -6,6 +6,10 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Callback;
+import com.google.android.gms.location.DetectedActivity;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class RNActivityRecognitionNativeModule extends ReactContextBaseJavaModule {
     private static final String REACT_CLASS = "ActivityRecognition";
@@ -22,6 +26,18 @@ public class RNActivityRecognitionNativeModule extends ReactContextBaseJavaModul
         mReactContext = reactContext;
     }
 
+    @Override
+    public Map<String, Object> getConstants() {
+        final Map<String, Object> constants = new HashMap<>();
+
+        // Export a few common activity types to allow easier mocking.
+        constants.put("ANDROID_STILL", DetectedActivity.STILL);
+        constants.put("ANDROID_WALKING", DetectedActivity.WALKING);
+        constants.put("ANDROID_IN_VEHICLE", DetectedActivity.IN_VEHICLE);
+
+        return constants;
+    }
+
     @ReactMethod
     public void startWithCallback(int detectionIntervalMillis, final Callback onSuccess, final Callback onError) {
         try {
@@ -33,6 +49,26 @@ public class RNActivityRecognitionNativeModule extends ReactContextBaseJavaModul
         } catch (Error e) {
             onError.invoke(e.getMessage());
             return;
+        }
+
+        onSuccess.invoke();
+    }
+
+    @ReactMethod
+    public void startMockedWithCallback(int detectionIntervalMillis, int mockActivityType, final Callback onSuccess, final Callback onError) {
+        if (mActivityRecognizer == null) {
+            mActivityRecognizer = new ActivityRecognizer(mReactContext);
+        }
+
+        mActivityRecognizer.startMocked((long) detectionIntervalMillis, mockActivityType);
+
+        onSuccess.invoke();
+    }
+
+    @ReactMethod
+    public void stopMockedWithCallback(final Callback onSuccess, final Callback onError) {
+        if (mActivityRecognizer != null) {
+            mActivityRecognizer.stopMocked();
         }
 
         onSuccess.invoke();

--- a/android/src/main/java/com/xebia/activityrecognition/RNActivityRecognitionNativeModule.java
+++ b/android/src/main/java/com/xebia/activityrecognition/RNActivityRecognitionNativeModule.java
@@ -23,17 +23,32 @@ public class RNActivityRecognitionNativeModule extends ReactContextBaseJavaModul
     }
 
     @ReactMethod
-    public void start(int detectionIntervalMillis) {
-        if (mActivityRecognizer == null) {
-            mActivityRecognizer = new ActivityRecognizer(mReactContext);
+    public void startWithCallback(int detectionIntervalMillis, final Callback onSuccess, final Callback onError) {
+        try {
+            if (mActivityRecognizer == null) {
+                mActivityRecognizer = new ActivityRecognizer(mReactContext);
+            }
+
+            mActivityRecognizer.start((long) detectionIntervalMillis);
+        } catch (Error e) {
+            onError.invoke(e.getMessage());
+            return;
         }
-        mActivityRecognizer.start(new Long(detectionIntervalMillis));
+
+        onSuccess.invoke();
     }
 
     @ReactMethod
-    public void stop() {
-        if (mActivityRecognizer != null) {
-            mActivityRecognizer.stop();
+    public void stopWithCallback(final Callback onSuccess, final Callback onError) {
+        try {
+            if (mActivityRecognizer != null) {
+                mActivityRecognizer.stop();
+            }
+        } catch (Error e) {
+            onError.invoke(e.getMessage());
+            return;
         }
+
+        onSuccess.invoke();
     }
 }

--- a/ios/RNActivityRecognition.m
+++ b/ios/RNActivityRecognition.m
@@ -69,31 +69,41 @@ float _timeout = 1.0;
     }
 }
 
-RCT_EXPORT_METHOD(startActivity:(float) time)
+RCT_EXPORT_METHOD(startActivity:(float)time callback:(RCTResponseSenderBlock)callback)
 {
-    checkActivityConfig();
+    NSString* errorMsg = checkActivityConfig(callback);
+    
+    if (errorMsg != nil) {
+        RCTLogError(@"%@", errorMsg);
+        callback(@[errorMsg]);
+        return;
+    }
+    
     _timeout = time/1000;
     RCTLogInfo(@"Starting Activity Detection");
     _timer = [NSTimer scheduledTimerWithTimeInterval: _timeout
                                               target:self selector:@selector(activityManager) userInfo:nil repeats:YES];
+    
+    callback(@[[NSNull null]]);
 }
 
-RCT_EXPORT_METHOD(stopActivity)
+RCT_EXPORT_METHOD(stopActivity:(RCTResponseSenderBlock)callback)
 {
     RCTLogInfo(@"Stopping Activity Detection");
     [self.motionActivityManager stopActivityUpdates];
     [_timer invalidate];
+    
+    callback(@[[NSNull null]]);
 }
 
-static void checkActivityConfig()
+static NSString* checkActivityConfig()
 {
 #if RCT_DEV
     if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMotionUsageDescription"]) {
-        RCTLogError(@"NSMotionUsageDescription key must be present in Info.plist to use Activity Manager.");
+        return @"NSMotionUsageDescription key must be present in Info.plist to use Activity Manager.";
     }
 #endif
+    return nil;
 }
 
-
 @end
-  

--- a/ios/RNActivityRecognition.m
+++ b/ios/RNActivityRecognition.m
@@ -65,7 +65,7 @@ float _timeout = 1.0;
                                                     }
          ];
     } else {
-        RCTLogInfo(@"Activity is Not Available on this device.");
+        RCTLogInfo(@"Motion data is not available on this device.");
     }
 }
 
@@ -101,6 +101,9 @@ static NSString* checkActivityConfig()
 #if RCT_DEV
     if (![[NSBundle mainBundle] objectForInfoDictionaryKey:@"NSMotionUsageDescription"]) {
         return @"NSMotionUsageDescription key must be present in Info.plist to use Activity Manager.";
+    }
+    if (![CMMotionActivityManager isActivityAvailable]) {
+        return @"Motion data is not available on this device.";
     }
 #endif
     return nil;

--- a/ios/RNActivityRecognition.m
+++ b/ios/RNActivityRecognition.m
@@ -74,7 +74,7 @@ RCT_EXPORT_METHOD(startActivity:(float)time callback:(RCTResponseSenderBlock)cal
     NSString* errorMsg = checkActivityConfig(callback);
     
     if (errorMsg != nil) {
-        RCTLogError(@"%@", errorMsg);
+        NSLog(@"Error: %@", errorMsg);
         callback(@[errorMsg]);
         return;
     }

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -3,6 +3,8 @@ const { ActivityRecognition } = NativeModules
 
 ActivityRecognition.subscribe = subscribe
 ActivityRecognition.start = start
+ActivityRecognition.startMocked = startMocked
+ActivityRecognition.stopMocked = stopMocked
 ActivityRecognition.stop = stop
 
 function subscribe(callback) {
@@ -22,6 +24,18 @@ function subscribe(callback) {
 function start(detectionIntervalMs) {
   return new Promise((resolve, reject) => {
     ActivityRecognition.startWithCallback(detectionIntervalMs, resolve, logAndReject.bind(null, reject))
+  });
+}
+
+function startMocked(detectionIntervalMs, mockActivityType) {
+  return new Promise((resolve, reject) => {
+    ActivityRecognition.startMockedWithCallback(detectionIntervalMs, mockActivityType, resolve, logAndReject.bind(null, reject))
+  });
+}
+
+function stopMocked() {
+  return new Promise((resolve, reject) => {
+    ActivityRecognition.stopMockedWithCallback(resolve, logAndReject.bind(null, reject))
   });
 }
 

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -1,48 +1,48 @@
 const { DeviceEventEmitter, NativeModules } = require('react-native')
-const { ActivityRecognition } = NativeModules
+const { ActivityRecognition: ActivityRecognitionNative } = NativeModules
 
-ActivityRecognition.subscribe = subscribe
-ActivityRecognition.start = start
-ActivityRecognition.startMocked = startMocked
-ActivityRecognition.stopMocked = stopMocked
-ActivityRecognition.stop = stop
+const ActivityRecognition = {
+  'ANDROID_STILL': ActivityRecognitionNative.ANDROID_STILL,
+  'ANDROID_WALKING': ActivityRecognitionNative.ANDROID_WALKING,
+  'ANDROID_IN_VEHICLE': ActivityRecognitionNative.ANDROID_IN_VEHICLE,
 
-function subscribe(callback) {
-  const subscription = DeviceEventEmitter.addListener('DetectedActivity', detectedActivities => {
-    callback({
-      ...detectedActivities,
-      get sorted() {
-        return Object.keys(detectedActivities)
-          .map(type => ({ type: type, confidence: detectedActivities[type] }))
-          .sort((a, b) => b.confidence - a.confidence)
-      },
+  subscribe(callback) {
+    const subscription = DeviceEventEmitter.addListener('DetectedActivity', detectedActivities => {
+      callback({
+        ...detectedActivities,
+        get sorted() {
+          return Object.keys(detectedActivities)
+            .map(type => ({ type: type, confidence: detectedActivities[type] }))
+            .sort((a, b) => b.confidence - a.confidence)
+        },
+      })
     })
-  })
-  return () => DeviceEventEmitter.removeSubscription(subscription)
-}
+    return () => DeviceEventEmitter.removeSubscription(subscription)
+  },
 
-function start(detectionIntervalMs) {
-  return new Promise((resolve, reject) => {
-    ActivityRecognition.startWithCallback(detectionIntervalMs, resolve, logAndReject.bind(null, reject))
-  });
-}
+  start(detectionIntervalMs) {
+    return new Promise((resolve, reject) => {
+      ActivityRecognitionNative.startWithCallback(detectionIntervalMs, resolve, logAndReject.bind(null, reject))
+    });
+  },
 
-function startMocked(detectionIntervalMs, mockActivityType) {
-  return new Promise((resolve, reject) => {
-    ActivityRecognition.startMockedWithCallback(detectionIntervalMs, mockActivityType, resolve, logAndReject.bind(null, reject))
-  });
-}
+  startMocked(detectionIntervalMs, mockActivityType) {
+    return new Promise((resolve, reject) => {
+      ActivityRecognitionNative.startMockedWithCallback(detectionIntervalMs, mockActivityType, resolve, logAndReject.bind(null, reject))
+    });
+  },
 
-function stopMocked() {
-  return new Promise((resolve, reject) => {
-    ActivityRecognition.stopMockedWithCallback(resolve, logAndReject.bind(null, reject))
-  });
-}
+  stopMocked() {
+    return new Promise((resolve, reject) => {
+      ActivityRecognitionNative.stopMockedWithCallback(resolve, logAndReject.bind(null, reject))
+    });
+  },
 
-function stop() {
-  return new Promise((resolve, reject) => {
-    ActivityRecognition.stopWithCallback(resolve, logAndReject.bind(null, reject))
-  });
+  stop() {
+    return new Promise((resolve, reject) => {
+      ActivityRecognitionNative.stopWithCallback(resolve, logAndReject.bind(null, reject))
+    });
+  },
 }
 
 function logAndReject(reject, errorMsg) {

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -2,6 +2,8 @@ const { DeviceEventEmitter, NativeModules } = require('react-native')
 const { ActivityRecognition } = NativeModules
 
 ActivityRecognition.subscribe = subscribe
+ActivityRecognition.start = start
+ActivityRecognition.stop = stop
 
 function subscribe(callback) {
   const subscription = DeviceEventEmitter.addListener('DetectedActivity', detectedActivities => {
@@ -15,6 +17,23 @@ function subscribe(callback) {
     })
   })
   return () => DeviceEventEmitter.removeSubscription(subscription)
+}
+
+function start(detectionIntervalMs) {
+  return new Promise((resolve, reject) => {
+    ActivityRecognition.startWithCallback(detectionIntervalMs, resolve, logAndReject.bind(null, reject))
+  });
+}
+
+function stop() {
+  return new Promise((resolve, reject) => {
+    ActivityRecognition.stopWithCallback(resolve, logAndReject.bind(null, reject))
+  });
+}
+
+function logAndReject(reject, e) {
+  console.error(`[ActivityRecognition] Error: ${e}`)
+  reject(e)
 }
 
 module.exports = ActivityRecognition

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -31,9 +31,9 @@ function stop() {
   });
 }
 
-function logAndReject(reject, e) {
-  console.error(`[ActivityRecognition] Error: ${e}`)
-  reject(e)
+function logAndReject(reject, errorMsg) {
+  console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+  reject(errorMsg)
 }
 
 module.exports = ActivityRecognition

--- a/src/ActivityRecognition.android.js
+++ b/src/ActivityRecognition.android.js
@@ -32,7 +32,8 @@ function stop() {
 }
 
 function logAndReject(reject, errorMsg) {
-  console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+  // Don't log this as an error, because the client should handle it using `catch`.
+  console.log(`[ActivityRecognition] Error: ${errorMsg}`)
   reject(errorMsg)
 }
 

--- a/src/ActivityRecognition.ios.js
+++ b/src/ActivityRecognition.ios.js
@@ -6,6 +6,10 @@ const emitter = new NativeEventEmitter(RNActivityRecognition);
 var subscription = null;
 
 var ActivityRecognition = {
+  'IOS_STATIONARY': RNActivityRecognition.IOS_STATIONARY,
+  'IOS_WALKING': RNActivityRecognition.IOS_WALKING,
+  'IOS_AUTOMOTIVE': RNActivityRecognition.IOS_AUTOMOTIVE,
+
   subscribe: function(success: Function) {
     subscription = emitter.addListener(
       "ActivityDetection",
@@ -21,11 +25,25 @@ var ActivityRecognition = {
     );
     return () => subscription.remove();
   },
+
   start: function(time: number) {
     return new Promise((resolve, reject) => {
       RNActivityRecognition.startActivity(time, logAndReject.bind(null, resolve, reject))
     })
   },
+
+  startMocked: function(time: number, mockActivity: string) {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.startMockedActivity(time, mockActivity, logAndReject.bind(null, resolve, reject))
+    })
+  },
+
+  stopMocked: function() {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.stopMockedActivity(logAndReject.bind(null, resolve, reject))
+    })
+  },
+
   stop: function() {
     return new Promise((resolve, reject) => {
       RNActivityRecognition.stopActivity(logAndReject.bind(null, resolve, reject))

--- a/src/ActivityRecognition.ios.js
+++ b/src/ActivityRecognition.ios.js
@@ -6,11 +6,6 @@ const emitter = new NativeEventEmitter(RNActivityRecognition);
 var subscription = null;
 
 var ActivityRecognition = {
-  start: function(time: number) {
-    return new Promise((resolve, reject) => {
-      RNActivityRecognition.startActivity(time, logAndReject.bind(null, resolve, reject))
-    })
-  },
   subscribe: function(success: Function) {
     subscription = emitter.addListener(
       "ActivityDetection",
@@ -25,6 +20,11 @@ var ActivityRecognition = {
       }
     );
     return () => subscription.remove();
+  },
+  start: function(time: number) {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.startActivity(time, logAndReject.bind(null, resolve, reject))
+    })
   },
   stop: function() {
     return new Promise((resolve, reject) => {

--- a/src/ActivityRecognition.ios.js
+++ b/src/ActivityRecognition.ios.js
@@ -35,7 +35,8 @@ var ActivityRecognition = {
 
 function logAndReject(resolve, reject, errorMsg) {
   if (errorMsg) {
-    console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+    // Don't log this as an error, because the client should handle it using `catch`.
+    console.log(`[ActivityRecognition] Error: ${errorMsg}`)
     reject(errorMsg)
     return
   }

--- a/src/ActivityRecognition.ios.js
+++ b/src/ActivityRecognition.ios.js
@@ -6,27 +6,40 @@ const emitter = new NativeEventEmitter(RNActivityRecognition);
 var subscription = null;
 
 var ActivityRecognition = {
-    start: function(time: number) {
-        RNActivityRecognition.startActivity(time);
-    },
-    subscribe: function(success: Function) {
-        subscription = emitter.addListener(
-            "ActivityDetection",
-            activity => {
-                success({
-                    ...activity,
-                    get sorted() {
-                        return Object.keys(activity)
-                            .map(type => ({ type: type, confidence: activity[type] }))
-                    }
-                })
-            }
-        );
-        return () => subscription.remove();
-    },
-    stop: function() {
-        RNActivityRecognition.stopActivity();
-    }
+  start: function(time: number) {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.startActivity(time, logAndReject.bind(null, resolve, reject))
+    })
+  },
+  subscribe: function(success: Function) {
+    subscription = emitter.addListener(
+      "ActivityDetection",
+      activity => {
+        success({
+          ...activity,
+          get sorted() {
+            return Object.keys(activity)
+              .map(type => ({ type: type, confidence: activity[type] }))
+          }
+        })
+      }
+    );
+    return () => subscription.remove();
+  },
+  stop: function() {
+    return new Promise((resolve, reject) => {
+      RNActivityRecognition.stopActivity(logAndReject.bind(null, resolve, reject))
+    })
+  }
+}
+
+function logAndReject(resolve, reject, errorMsg) {
+  if (errorMsg) {
+    console.error(`[ActivityRecognition] Error: ${errorMsg}`)
+    reject(errorMsg)
+    return
+  }
+  resolve()
 }
 
 module.exports = ActivityRecognition;


### PR DESCRIPTION
### Motivation

Neither Android nor iOS has good support for mocking activity recognition (see [this answer](https://stackoverflow.com/a/46286931/763231) and [this library](https://github.com/AlohaYos/GeoFake) to get an idea). It's very difficult to test a production app without some way of mocking these events.

### Changes

- Added methods for `startMocked` and `stopMocked` (both iOS and Android)
- Exported some basic constants to use as mock activity types, based on platform
- Made JS method exports consistent across Android and iOS (previously Android exported the native module directly with all of its raw methods; now it's a separate object like iOS)

⚠️  **Note: This PR is currently based on https://github.com/Aminoid/react-native-activity-recognition/pull/4, so the diff is inaccurate. See [here](https://github.com/cribspot/react-native-activity-recognition/compare/handle-errors...add-mock-data) for the real diff.** I can rebase after #4 is merged.

### Example

```js
const mockActivity = Platform.OS === 'ios'
  ? ActivityRecognition.IOS_AUTOMOTIVE
  : ActivityRecognition.ANDROID_IN_VEHICLE;

ActivityRecognition.startMocked(1000, mockActivity);
ActivityRecognition.stopMocked();
```
