### PR TITLE
Add missing homepage value to podspec file

### DIFF
--- a/ios/RNActivityRecognition.podspec
+++ b/ios/RNActivityRecognition.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNActivityRecognition
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/Aminoid/react-native-activity-recognition"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
I was getting errors using 
```
$ pod --version
1.5.3
```

because of this missing value in the `podspec` file.