### PR TITLE
Compatibility with react-native 0.61.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ public class MainApplication extends Application implements ReactApplication {
 </application>
 ...
 ```
+Also add the `ACTIVITY_RECOGNITION` permission on the manifest to support Android API Level above 28
+```xml
+<manifest ...>
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
+    ...
+</manifest>
+```
 
 #### iOS
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,5 +39,5 @@ android {
 
 dependencies {
     api 'com.facebook.react:react-native:+'
-    api 'com.google.android.gms:play-services:+'
+    api 'com.google.android.gms:play-services-location:+'
 }

--- a/ios/RNActivityRecognition.podspec
+++ b/ios/RNActivityRecognition.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNActivityRecognition
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/Aminoid/react-native-activity-recognition"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }

--- a/ios/RNActivityRecognition.podspec
+++ b/ios/RNActivityRecognition.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNActivityRecognition.git", :tag => "master" }
-  s.source_files  = "RNActivityRecognition/**/*.{h,m}"
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
 
 


### PR DESCRIPTION
There were all the changes needed to makes this compatible with the auto link feature of React Native 0.61.5.
Also update the Readme since Android Q now requires a permission in order to use the activity recognition.